### PR TITLE
feat: Handle line and form coverage separately with new flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ## Changed
 
+# TODO (2024-02-27 / 162112b)
+
+## Changed
+
+- Add support for new cloverage flags `--line-fail-threshold` and `--form-fail-threshold` 
+
 # 1.1.89 (2022-11-09 / c2b2dbf)
 
 ## Added

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Alternatively Cloverage can be configured through `tests.edn`. Source paths spec
   :lcov? false,
   :high-watermark 80,
   :fail-threshold 0,
+  :line-fail-threshold 0,
+  :form-fail-threshold 0,
   :output "target/coverage",
   :low-watermark 50,
   :ns-regex [],

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["src"]
  :deps  {org.clojure/clojure {:mvn/version "1.10.1"}
          lambdaisland/kaocha {:mvn/version "0.0-601"}
-         cloverage/cloverage {:git/url    "https://github.com/krikitti/cloverage"
-                              :sha        "fa9af44de351a4c8b44f30da47c32ea827cc55ef"
+         cloverage/cloverage {:git/url    "https://github.com/ekataglobal/cloverage"
+                              :sha        "b49e6f54945f172f15a3c7c89296db98d27bf914"
                               :deps/root  "cloverage"}}
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,9 @@
 {:paths ["src"]
  :deps  {org.clojure/clojure {:mvn/version "1.10.1"}
          lambdaisland/kaocha {:mvn/version "0.0-601"}
-         cloverage/cloverage {:mvn/version "1.2.4"}}
+         cloverage/cloverage {:git/url    "https://github.com/krikitti/cloverage"
+                              :sha        "fa9af44de351a4c8b44f30da47c32ea827cc55ef"
+                              :deps/root  "cloverage"}}
  :aliases
  {:dev
   {}

--- a/src/kaocha/plugin/cloverage.clj
+++ b/src/kaocha/plugin/cloverage.clj
@@ -20,6 +20,8 @@
    :coveralls? false
    :summary? true
    :fail-threshold 0
+   :line-fail-threshold 0
+   :form-fail-threshold 0
    :low-watermark 50
    :high-watermark 80
    :nop? false
@@ -44,7 +46,15 @@
    ["--[no-]cov-summary"
     "Prints a summary"]
    ["--cov-fail-threshold PERCENT"
-    "Sets the percentage threshold at which cloverage will abort the build. Default: 0%"
+    "Sets the percentage threshold for both line and form coverageat which cloverage will abort the build. Default: 0%"
+    :parse-fn #(Integer/parseInt %)]
+   ["--cov-line-fail-threshold PERCENT"
+    "Sets the percentage threshold for line coverage at which cloverage will abort the build.
+    Ignored if --cov-fail-threshold is non-zero. Default: 0%"
+    :parse-fn #(Integer/parseInt %)]
+   ["--cov-form-fail-threshold PERCENT"
+    "Sets the percentage threshold for form coverage at which cloverage will abort the build.
+    Ignored if --cov-fail-threshold is non-zero. Default: 0%"
     :parse-fn #(Integer/parseInt %)]
    ["--cov-low-watermark PERCENT"
     "Sets the low watermark percentage (valid values 0..100). Default: 50%"
@@ -102,6 +112,12 @@
 
                (contains? opts :cov-fail-threshold)
                (assoc :fail-threshold (:cov-fail-threshold opts))
+
+               (contains? opts :cov-line-fail-threshold)
+               (assoc :line-fail-threshold (:cov-line-fail-threshold opts))
+
+               (contains? opts :cov-form-fail-threshold)
+               (assoc :form-fail-threshold (:cov-form-fail-threshold opts))
 
                (contains? opts :cov-low-watermark)
                (assoc :low-watermark (:cov-low-watermark opts))

--- a/test/unit/kaocha/plugin/cloverage_test.clj
+++ b/test/unit/kaocha/plugin/cloverage_test.clj
@@ -103,6 +103,18 @@
       (is (match? {:fail-threshold 42} (update-config' {:fail-threshold 20} ["--cov-fail-threshold" "42"])))
       (is (match? {:fail-threshold 42} (update-config' {} ["--cov-fail-threshold" "42"]))))
 
+    (testing "--cov-line-fail-threshold PERCENT"
+      (is (match? {:line-fail-threshold 0} (update-config' {} [])))
+      (is (match? {:line-fail-threshold 20} (update-config' {:line-fail-threshold 20} [])))
+      (is (match? {:line-fail-threshold 42} (update-config' {:line-fail-threshold 20} ["--cov-line-fail-threshold" "42"])))
+      (is (match? {:line-fail-threshold 42} (update-config' {} ["--cov-line-fail-threshold" "42"]))))
+
+    (testing "--cov-form-fail-threshold PERCENT"
+      (is (match? {:form-fail-threshold 0} (update-config' {} [])))
+      (is (match? {:form-fail-threshold 20} (update-config' {:form-fail-threshold 20} [])))
+      (is (match? {:form-fail-threshold 42} (update-config' {:form-fail-threshold 20} ["--cov-form-fail-threshold" "42"])))
+      (is (match? {:form-fail-threshold 42} (update-config' {} ["--cov-form-fail-threshold" "42"]))))
+
     (testing "--cov-low-watermark PERCENT"
       (is (match? {:low-watermark 50} (update-config' {} [])))
       (is (match? {:low-watermark 20} (update-config' {:low-watermark 20} [])))


### PR DESCRIPTION
Use cloverage from ekataglobal fork to utilize the new threshold flags.